### PR TITLE
enable direct maps on multiple mounts

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -40,7 +40,7 @@ define autofs::mount (
   $execute=false
 ) {
 
-  concat::fragment { "autofs::fragment preamble ${mount}":
+  concat::fragment { "autofs::fragment preamble ${mount} ${mapfile}":
     ensure  => present,
     target  => '/etc/auto.master',
     content => "${mount} ${mapfile} ${options}\n",

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -21,7 +21,7 @@ describe 'autofs::mount', :type => :define do
   context 'with default parameters' do
 
     it do
-      should contain_concat__fragment('autofs::fragment preamble /home').with('target' => '/etc/auto.master')
+      should contain_concat__fragment('autofs::fragment preamble /home /etc/auto.home').with('target' => '/etc/auto.master')
     end
 
 #    it do


### PR DESCRIPTION
With this change puppet will create multiple resources with unique names for the auto.master fragments if you want to create a direct map for every mount in a hash.
