### PR TITLE
added dependency on basic nfs functionality for ubuntu and centos/redhat

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -8,10 +8,10 @@ class autofs::package {
   }
   case $::osfamily {
     'Debian', 'Ubuntu': {
-      package { 'autofs': }
+      package { ['autofs', 'nfs-common']: }
     }
     'RedHat', 'CentOS': {
-      package { 'autofs': }
+      package { ['autofs', 'nfs-utils']: }
     }
     'Solaris': {
       # Solaris includes autofs


### PR DESCRIPTION
It turns out that at least on redhat 6/7 there could be a case of nfs-utils not being installed. This results in autofs mounts not working. I added nfs-utils for redhat and nfs-common for ubuntu to circumvent this
