### PR TITLE
Added the Suse package name

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -13,6 +13,9 @@ class autofs::package {
     'RedHat', 'CentOS': {
       package { 'autofs': }
     }
+    'Suse': {
+      package { 'autofs': }
+    }
     'Solaris': {
       # Solaris includes autofs
       # Block to prevent failures


### PR DESCRIPTION
After adding the package name for SUSE, I can confirm this module now works on various versions of SLES and openSUSE.  Addresses issue #24.